### PR TITLE
fix(src/maps/OsmRasterTileStyle.ts): change out dated url to recommended format

### DIFF
--- a/src/maps/OsmRasterTileStyle.ts
+++ b/src/maps/OsmRasterTileStyle.ts
@@ -4,9 +4,7 @@ export const OSM_RASTER_TILE_STYLE: mapboxgl.Style = {
     "osm-raster-tiles": {
       type: "raster",
       tiles: [
-        "https://a.tile.openstreetmap.org/{z}/{x}/{y}.png",
-        "https://b.tile.openstreetmap.org/{z}/{x}/{y}.png",
-        "https://c.tile.openstreetmap.org/{z}/{x}/{y}.png",
+        "https://tile.openstreetmap.org/{z}/{x}/{y}.png",
       ],
       tileSize: 256,
       attribution: "© OpenStreetMap contributors",


### PR DESCRIPTION
## About this pull request

Haven't seen you for a long time.

This commit changes legacy load balancing subdomain url to new unified osm tiles url according to operation group's announcement. 

Currently discovering and submitting PRs to projects on Github that still use legacy URL. See https://github.com/openstreetmap/operations/issues/737

They also announced this on Twitter: https://twitter.com/OSM_Tech/status/1601625779036893190

## Related issues

None

## What you checked

- [ ] Existing feature works correctly
- [ ] Added changes works correctly

## Related URLs

None

## Screenshots

### Before

None

### After

None